### PR TITLE
handle security group creation better

### DIFF
--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -455,6 +455,27 @@ update_aws_sec_group () {
     exit 3
   fi
 
+  # loop over the rules - each rule dict must be base64 encoded as
+  # whitespace breaks the looping
+  for rule in $(echo "${SECGROUP_DATA}" | jq -r '.SecurityGroups[0].IpPermissions[] | @base64'); do
+    # get the port for this rule
+    _FROM_PORT=$(echo "${rule}" | base64 -d | jq -r .FromPort)
+
+    # only examine it if it is the K8S API rule
+    if [[ $_FROM_PORT -eq 443 ]]; then
+      # get the allowed IP range to this port
+      _CIDR_IP=$(echo "${rule}" | base64 -d | jq -r .IpRanges[0].CidrIp)
+      # if the port is already open to the world then return from the function
+      if [[ "${_CIDR_IP}" == "0.0.0.0/0" ]]; then
+        echo "API ingress already allowed from \"0.0.0.0/0\""
+        return
+      fi
+    fi
+  done
+
+  # rule doesn't exist or isn't open to the world, so we need to create a new rule
+  SEC_GROUP_ID=$(jq .SecurityGroups[0].GroupId <<< ${SECGROUP_DATA})
+
   info "Adding ingress rule for 0.0.0.0/0 to Security Group ${SEC_GROUP_ID}"
   # add a new rule to allow ingress from anywhere on 443
   aws ec2 authorize-security-group-ingress --region ${REGION} --group-id ${SEC_GROUP_ID} \

--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -478,10 +478,8 @@ update_aws_sec_group () {
 
   info "Adding ingress rule for 0.0.0.0/0 to Security Group ${SEC_GROUP_ID}"
   # add a new rule to allow ingress from anywhere on 443
-  aws ec2 authorize-security-group-ingress --region ${REGION} --group-id ${SEC_GROUP_ID} \
-    --protocol tcp --port 443 --cidr 0.0.0.0/0
-
-  if [[ "$?" -gt 0 ]]; then
+  if ! aws ec2 authorize-security-group-ingress --region ${REGION} --group-id ${SEC_GROUP_ID} \
+      --protocol tcp --port 443 --cidr 0.0.0.0/0 ; then
     err "Could not add ingress rule to the Security Group."
     exit 3
   fi

--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -446,17 +446,12 @@ EOF
 update_aws_sec_group () {
   cluster_id=$1
 
-  info "Getting Security Group ID for cluster ${cluster_id}"
-  # get the security group ID for the new cluster
-  SEC_GROUP_ID=$(aws ec2 describe-security-groups --region ${REGION} \
-    --filters Name=tag:giantswarm.io/cluster,Values=${cluster_id} \
-    Name=tag:aws:cloudformation:logical-id,Values=MasterSecurityGroup \
-    | jq -r .SecurityGroups[0].GroupId)
-
-  # check that we actually got a key pair back
-  grep -q "sg-" <<< $SEC_GROUP_ID
-  if [[ "$?" -gt 0 ]]; then
-    err "Could not find the Security Group ID."
+  info "Getting Security Group details for cluster ${cluster_id}"
+  # get the security group details for the new cluster's K8S API ingress
+  if ! SECGROUP_DATA=$(aws ec2 describe-security-groups --region ${REGION} \
+      --filters Name=tag:giantswarm.io/cluster,Values=${cluster_id} \
+      Name=tag:aws:cloudformation:logical-id,Values=MasterSecurityGroup) ; then
+    err "Error describing the Security Group."
     exit 3
   fi
 


### PR DESCRIPTION
the script fails when a security group for `443` & `0.0.0.0/0` already exists, so we inspect the rules first and exit the function earlier if a match is found.
