### PR TITLE
Allow the cluster to start fully

### DIFF
--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -849,7 +849,7 @@ verify_helm () {
       info "Deployment ${chart_name} is ${expected}!"
       break
     fi
-    sleep 1
+    sleep 5
     timer=$((timer+1))
     if [[ $timer -gt $MAX_WAIT_FOR_HELM_STATUS_DEPLOY_SEC ]]; then
       err "Deployment ${chart_name} failed to become ${expected} in ${MAX_WAIT_FOR_HELM_STATUS_DEPLOY_SEC} seconds."


### PR DESCRIPTION
The helm check failed because coredns hadn't deployed in 3 minutes and as a result the chart-museum svc didn't resolve.
