### PR TITLE
add bitnami repo to make it run properly

### DIFF
--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -792,11 +792,11 @@ validate_chart () {
 
   info "Linting chart \"${chart_name}\" with \"ct\""
   CT_DOCKER_RUN="docker run -it --rm -v $(pwd):/chart -w /chart quay.io/helmpack/chart-testing:${CHART_TESTING_VERSION_TAG}"
-  if [[ -n "${CT_CONFIG_FILE}" ]]
+    if [[ -n "${CT_CONFIG_FILE}" ]]
   then
-    $CT_DOCKER_RUN sh -c "helm init -c && ct lint --config $CT_CONFIG_FILE --validate-maintainers=false --charts=\"helm/${chart_name}\""
+    $CT_DOCKER_RUN sh -c "helm init -c && helm repo add bitnami https://charts.bitnami.com/bitnami && ct lint --config $CT_CONFIG_FILE --validate-maintainers=false --charts=\"helm/${chart_name}\""
   else
-    $CT_DOCKER_RUN sh -c "helm init -c && ct lint --validate-maintainers=false --charts=\"helm/${chart_name}\""
+    $CT_DOCKER_RUN sh -c "helm init -c && helm repo add bitnami https://charts.bitnami.com/bitnami && ct lint --validate-maintainers=false --charts=\"helm/${chart_name}\""
   fi
 
   if [[ $VALIDATE_ONLY -eq 1 ]]; then


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

When I run it locally I got this error:

```
$HELM_HOME has been configured at /root/.helm.
Not installing Tiller due to 'client-only' flag having been set
Error: no repository definition for https://charts.bitnami.com/bitnami. Please add the missing repos via 'helm repo add'
Error linting charts: Error building dependencies for chart 'kong-app => (version: "0.8.3-194cc3dd5a37c66312c45328c052d4547433e835", path: "helm/kong-app")': Error waiting for process: exit status 1
-```

fixed by the PR