### PR TITLE
init helm with --stable-repo-url

### DIFF
--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -39,7 +39,7 @@ ARCHITECT_VERSION_TAG=latest
 APP_OPERATOR_VERSION_TAG=${APP_OPERATOR_VERSION_TAG:-1.0.7}
 CHART_OPERATOR_VERSION_TAG=${CHART_OPERATOR_VERSION_TAG:-0.13.1}
 CHART_MUSEUM_VERSION_TAG=${CHART_MUSEUM_VERSION_TAG:-v0.12.0}
-PYTHON_VERSION_TAG=3.7-alpine
+PYTHON_VERSION_TAG=3.8-alpine
 CHART_TESTING_VERSION_TAG=v2.4.0
 
 ####################
@@ -1122,7 +1122,7 @@ parse_args () {
   CLUSTER_NAME=${CLUSTER_NAME:-$DEFAULT_CLUSTER_NAME}
   # generate and apply a random suffix to the cluster name to avoid cluster name
   # collisions when spawning a TC.
-  CLUSTER_NAME_SUFFIX=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
+  CLUSTER_NAME_SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 10 | head -n 1)
   CLUSTER_NAME=${CLUSTER_NAME}-${CLUSTER_NAME_SUFFIX}
 
   CLUSTER_TYPE=${CLUSTER_TYPE:-$DEFAULT_CLUSTER_TYPE}

--- a/kube-app-testing.sh
+++ b/kube-app-testing.sh
@@ -9,7 +9,7 @@
 # - use external kubeconfig - to run on already existing cluster
 
 # const
-KAT_VERSION=0.5.2
+KAT_VERSION=0.5.3
 
 # config
 CONFIG_DIR=/tmp/kat_test
@@ -780,7 +780,7 @@ validate_chart () {
   chart_name=$1
 
   if [[ ! -d ${HOME}/.helm ]]; then
-    helm init -c
+    helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
   fi
 
   info "Taking backups of 'Chart.yaml' and 'values.yaml' before 'architect' alters them"
@@ -794,9 +794,9 @@ validate_chart () {
   CT_DOCKER_RUN="docker run -it --rm -v $(pwd):/chart -w /chart quay.io/helmpack/chart-testing:${CHART_TESTING_VERSION_TAG}"
   if [[ -n "${CT_CONFIG_FILE}" ]]
   then
-    $CT_DOCKER_RUN sh -c "helm init -c && ct lint --config $CT_CONFIG_FILE --validate-maintainers=false --charts=\"helm/${chart_name}\""
+    $CT_DOCKER_RUN sh -c "helm init --stable-repo-url=https://charts.helm.sh/stable --client-only && ct lint --config $CT_CONFIG_FILE --validate-maintainers=false --charts=\"helm/${chart_name}\""
   else
-    $CT_DOCKER_RUN sh -c "helm init -c && ct lint --validate-maintainers=false --charts=\"helm/${chart_name}\""
+    $CT_DOCKER_RUN sh -c "helm init --stable-repo-url=https://charts.helm.sh/stable --client-only && ct lint --validate-maintainers=false --charts=\"helm/${chart_name}\""
   fi
 
   if [[ $VALIDATE_ONLY -eq 1 ]]; then


### PR DESCRIPTION
Should resolve the `Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden` error